### PR TITLE
feat(rxjs): enable minor upgrades

### DIFF
--- a/angularWorkspace.json
+++ b/angularWorkspace.json
@@ -11,8 +11,15 @@
     {
       "groupName": "Angular workspace",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^typescript", "^rxjs"],
+      "matchPackagePatterns": ["^typescript"],
       "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "groupName": "Angular workspace",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^rxjs"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {

--- a/nrwlWorkspace.json
+++ b/nrwlWorkspace.json
@@ -11,8 +11,15 @@
     {
       "groupName": "Nrwl workspace",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^typescript", "^rxjs"],
+      "matchPackagePatterns": ["^typescript"],
       "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "groupName": "Nrwl workspace",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^rxjs"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Since Angular v13 the dependency of rxjs no longer needs to be pinned to a patch version of v6. This change enables upgrades to minor versions, since now in v7 that should be supported

Related to https://github.com/ng-easy/platform/issues/487

cc @johannesschobel